### PR TITLE
feat: save shell output artifacts

### DIFF
--- a/src/strataregula_doe_runner/adapters/shell.py
+++ b/src/strataregula_doe_runner/adapters/shell.py
@@ -55,12 +55,14 @@ class ShellAdapter(BaseAdapter):
                 text=True,
                 timeout=int(case.get('timeout_s', 30))
             )
-            
+
             execution_time = time.time() - start_time
-            
+
             # 出力からメトリクスを抽出
             metrics = self._parse_metrics(result.stdout + result.stderr)
-            
+            metrics['stdout'] = result.stdout
+            metrics['stderr'] = result.stderr
+
             # 実行時間情報を追加
             metrics['execution_time'] = execution_time
             

--- a/src/strataregula_doe_runner/core/runner.py
+++ b/src/strataregula_doe_runner/core/runner.py
@@ -30,6 +30,8 @@ class ExecutionResult:
     errors: int
     ts_start: str
     ts_end: str
+    stdout_path: str = ""
+    stderr_path: str = ""
     # 追加メタデータ
     cpu_util: Optional[float] = None
     mem_peak_mb: Optional[float] = None

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -96,8 +96,9 @@ class TestEndToEndWorkflow:
         assert len(rows) == 3  # All 3 cases should be executed
         
         # Verify required columns
-        expected_columns = ['case_id', 'status', 'run_seconds', 'p95', 'p99', 
-                          'throughput_rps', 'errors', 'ts_start', 'ts_end']
+        expected_columns = ['case_id', 'status', 'run_seconds', 'p95', 'p99',
+                          'throughput_rps', 'errors', 'ts_start', 'ts_end',
+                          'stdout_path', 'stderr_path']
         for col in expected_columns:
             assert col in rows[0].keys()
         
@@ -111,6 +112,12 @@ class TestEndToEndWorkflow:
         assert results_by_id['test-02']['status'] == 'OK'
         assert float(results_by_id['test-02']['p95']) == 0.08
         assert float(results_by_id['test-02']['throughput_rps']) == 500
+        stdout_path = results_by_id['test-02']['stdout_path']
+        stderr_path = results_by_id['test-02']['stderr_path']
+        assert stdout_path and Path(stdout_path).exists()
+        assert Path(stdout_path).read_text().strip() == 'p95=0.08 p99=0.12 throughput_rps=500'
+        assert stderr_path and Path(stderr_path).exists()
+        assert Path(stderr_path).read_text() == ''
         
         # test-03 (threshold violation) should succeed but violate threshold
         assert results_by_id['test-03']['status'] == 'OK'


### PR DESCRIPTION
## Summary
- capture stdout and stderr for shell executions and store under artifacts
- record artifact paths in ExecutionResult and metrics output
- test coverage for artifact paths

## Testing
- `pre-commit run --files src/strataregula_doe_runner/core/runner.py src/strataregula_doe_runner/adapters/shell.py src/strataregula_doe_runner/core/executor.py tests/test_end_to_end.py` (failed: command not found: pre-commit)
- `pip install pre-commit` (failed: Could not find a version that satisfies the requirement pre-commit)
- `pip install pytest-cov` (failed: Could not find a version that satisfies the requirement pytest-cov)
- `pytest -q -o addopts=''` (failed: ModuleNotFoundError: No module named 'strataregula_doe_runner')
- `PYTHONPATH=src pytest -q -o addopts=''` (failed: 15 failed, 2 passed in 0.49s)
- `PYTHONPATH=src pytest --cov=src -o addopts=''` (failed: unrecognized arguments: --cov=src)
- `PYTHONPATH=src python -m strataregula_doe_runner.cli --help`
- `EQUALITY_CHECK_CMD` (failed: command not found: EQUALITY_CHECK_CMD)
- `LEGACY_CHECK_CMD` (failed: command not found: LEGACY_CHECK_CMD)
- `python scripts/new_run_log.py --label artifact-logging` (failed: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68b107180368832f9e7766adbdc324ed