### PR TITLE
feat(core): observability flags (default OFF) + LF line endings + run_id column

### DIFF
--- a/src/strataregula_doe_runner/adapters/shell.py
+++ b/src/strataregula_doe_runner/adapters/shell.py
@@ -60,7 +60,9 @@ class ShellAdapter(BaseAdapter):
             
             # 出力からメトリクスを抽出
             metrics = self._parse_metrics(result.stdout + result.stderr)
-            
+            metrics['stdout'] = result.stdout
+            metrics['stderr'] = result.stderr
+
             # 実行時間情報を追加
             metrics['execution_time'] = execution_time
             

--- a/src/strataregula_doe_runner/core/config.py
+++ b/src/strataregula_doe_runner/core/config.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from pathlib import Path
+import os
+import datetime
+
+
+def _b(env, default):
+    v = os.getenv(env)
+    return default if v is None else v not in ("0", "false", "False", "off", "OFF")
+
+
+def _run_id():
+    jst = datetime.timezone(datetime.timedelta(hours=9))
+    return datetime.datetime.now(jst).strftime("%Y%m%d-%H%M%S-JST")
+
+
+@dataclass(frozen=True)
+class Config:
+    obs_enabled: bool = _b("SR_OBS_ENABLED", False)
+    save_stdout: bool = _b("SR_SAVE_STDOUT", False)
+    trace_level: str = os.getenv("SR_TRACE_LEVEL", "none")
+    artifacts_dir: Path = Path(os.getenv("SR_ARTIFACTS_DIR", "artifacts"))
+    run_id: str = os.getenv("SR_RUN_ID", _run_id())

--- a/src/strataregula_doe_runner/io/csv_handler.py
+++ b/src/strataregula_doe_runner/io/csv_handler.py
@@ -36,7 +36,7 @@ class CSVHandler:
         columns = sorted(all_columns)
         
         with open(file_path, 'w', encoding='utf-8', newline='') as f:
-            writer = csv.DictWriter(f, fieldnames=columns)
+            writer = csv.DictWriter(f, fieldnames=columns, lineterminator='\n')
             writer.writeheader()
             for row in metrics_data:
                 writer.writerow(row)


### PR DESCRIPTION
## 目的 / 背景
- 本番では観測処理を無効化し軽量動作を維持するため、観測系をフラグで一元管理
- 後続の観測・トリアージ拡張を段階的に導入できる土台を構築

## 変更内容
- `Config` を追加し、`SR_OBS_ENABLED` / `SR_SAVE_STDOUT` / `SR_TRACE_LEVEL` などの環境変数で観測を制御（既定OFF）
- `CaseExecutor` で stdout/stderr 保存をフラグでガードし、`Runner` から設定を渡す構造に変更
- metrics CSV に `run_id` 列を追加し、改行コードを LF 固定に統一
- `ShellAdapter` が stdout/stderr を返すよう変更
- 付随するテストを更新

## 互換性 / 影響範囲
- 既存 CLI / API 互換。観測機能はデフォルトで無効
- CSV に `run_id` 列が追加されるが後方互換

## 動作確認
- `PYTHONPATH=src pytest -q -o addopts=`
- `PYTHONPATH=src pytest --cov=src` *(pytest-cov 不在で実行失敗)*
- `export SR_OBS_ENABLED=0 SR_SAVE_STDOUT=0 SR_TRACE_LEVEL=none; PYTHONPATH=src python -m strataregula_doe_runner.cli run --cases /tmp/cases.csv --out /tmp/metrics.csv -v`
- `export SR_OBS_ENABLED=1 SR_SAVE_STDOUT=1 SR_TRACE_LEVEL=basic; PYTHONPATH=src python -m strataregula_doe_runner.cli run --cases /tmp/cases.csv --out /tmp/metrics_dev.csv -v --force`
- `python scripts/new_run_log.py --label test` *(ファイル不存在で失敗)*


------
https://chatgpt.com/codex/tasks/task_e_68b11c31894c832f91baaa215d877792